### PR TITLE
add use of the namespace of the Route class to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ class AppKernel extends Kernel
 1. Implement [`RouteCollectionProviderInterface`](src/Contract/Routing/RouteCollectionProviderInterface.php)
 
     ```php
+    use Symfony\Component\Routing\Route;
     use Symfony\Component\Routing\RouteCollection;
     use Symplify\ModularRouting\Contract\Routing\RouteCollectionProviderInterface;
     


### PR DESCRIPTION
There was no use statement for the used Route class in the example in README.md
